### PR TITLE
feat: add dark-mode theming support via mode and colors props

### DIFF
--- a/.changeset/cell-diagram-dark-mode.md
+++ b/.changeset/cell-diagram-dark-mode.md
@@ -1,0 +1,25 @@
+---
+"@wso2/cell-diagram": minor
+---
+
+Add `mode` and `colors` props to `<CellDiagram>` for externally driven theming.
+
+- `mode?: 'light' | 'dark'` — defaults to `'light'` so existing callers see no
+  visual change. Pass `'dark'` to render the diagram with the new dark
+  preset.
+- `colors?: Partial<CellDiagramColors>` — merge per-token overrides on top
+  of the active preset. Useful for snapping the diagram's accents to a host
+  application's brand palette.
+
+The new `CellDiagramColors`, `CellDiagramThemeMode`, `lightColors`, and
+`darkColors` exports allow advanced consumers to introspect or build their
+own palettes.
+
+Internally the library now wraps its tree in an Emotion `ThemeProvider` so
+all styled components receive their colors through `theme.colors.*`. The
+historical `Colors` enum is retained as a frozen object alias of
+`lightColors`, so any code importing `Colors` directly continues to compile
+and renders the light palette.
+
+Brand language-icon SVGs (Java blue, Python yellow, etc.) are intentionally
+kept identity-colored in both modes.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,90 @@
 # cell-diagram
-A library which provides a diagram that can represent the cell-architecture
+
+A React component library that visualizes cell architectures.
+
+## Installation
+
+```bash
+npm install @wso2/cell-diagram
+```
+
+## Basic usage
+
+```tsx
+import { CellDiagram } from '@wso2/cell-diagram';
+
+<CellDiagram project={project} />;
+```
+
+## Theming (light / dark)
+
+`<CellDiagram>` accepts an optional `mode` prop and, for advanced cases, a
+`colors` prop that lets host applications drive the palette from the outside.
+Defaults are unchanged — callers that don't pass `mode` get the original
+light appearance.
+
+### Switching modes
+
+```tsx
+import { CellDiagram } from '@wso2/cell-diagram';
+
+// Follow the host application's theme.
+<CellDiagram project={project} mode={isDarkTheme ? 'dark' : 'light'} />;
+```
+
+The library subscribes its internal styled components to an Emotion
+`ThemeProvider`, so toggling `mode` re-renders the canvas live; zoom, layout
+and selection state persist across the swap.
+
+### Backstage example
+
+```tsx
+import { useTheme } from '@material-ui/core/styles';
+
+export function CellDiagramTab({ project }) {
+  const theme = useTheme();
+  return (
+    <CellDiagram
+      project={project}
+      mode={theme.palette.type === 'dark' ? 'dark' : 'light'}
+    />
+  );
+}
+```
+
+### Per-token overrides
+
+For host apps that want to snap accents to their own brand without giving up
+the rest of the preset, pass `colors`:
+
+```tsx
+import { CellDiagram, CellDiagramColors } from '@wso2/cell-diagram';
+
+const brandOverride: Partial<CellDiagramColors> = {
+  PRIMARY: '#22D3EE',
+  PRIMARY_HOVER: '#67E8F9',
+};
+
+<CellDiagram project={project} mode="dark" colors={brandOverride} />;
+```
+
+The full token set is exported as `CellDiagramColors` and the two presets as
+`lightColors` / `darkColors`.
+
+### What's themed and what isn't
+
+Themed surfaces include the canvas background, all node types
+(cell/component/connection/project/external), all link layers
+(architecture/observability/diff), legend, controls and tooltips.
+
+**Not themed**: brand language-icon SVGs (Java blue, Python yellow, NodeJS
+green, etc.) — those are kept identity-colored in both modes.
+
+## Migration from `0.2.x`
+
+- The `Colors` enum at `@wso2/cell-diagram` was previously a TypeScript
+  `enum`. From `0.3.0` it is a frozen object alias of `lightColors`. Value
+  imports (`Colors.PRIMARY`) keep working unchanged. Type imports
+  (`: Colors`) also keep working through a `type Colors = CellDiagramColors`
+  alias.
+- Callers that don't pass `mode` see no visual change.

--- a/src/Diagram.tsx
+++ b/src/Diagram.tsx
@@ -23,9 +23,16 @@ import "./resources/assets/font/fonts.css";
 import { ProjectDiagram } from "./diagrams/ProjectDiagram";
 import { PromptScreen } from "./components";
 import { OrgDiagram } from "./diagrams/OrgDiagram";
+import {
+    CellDiagramColors,
+    CellDiagramThemeMode,
+    CellDiagramThemeProvider,
+} from "./theme";
 
 export { DiagramLayer } from "./types";
 export type { MoreVertMenuItem, Project } from "./types";
+export type { CellDiagramColors, CellDiagramThemeMode } from "./theme";
+export { lightColors, darkColors } from "./theme";
 
 export interface CellDiagramProps {
     organization?: Organization;
@@ -35,23 +42,35 @@ export interface CellDiagramProps {
     animation?: boolean;
     defaultDiagramLayer?: DiagramLayer;
     customTooltips?: CustomTooltips;
-    modelVersion?: string; 
+    modelVersion?: string;
     previewMode?: boolean;
     onComponentDoubleClick?: (componentId: string) => void;
+    /**
+     * Color scheme to render the diagram in. Defaults to `'light'` so
+     * existing callers see no visual change.
+     */
+    mode?: CellDiagramThemeMode;
+    /**
+     * Optional per-token overrides merged on top of the `mode` preset. Use
+     * this to snap the diagram to a host application's brand palette.
+     */
+    colors?: Partial<CellDiagramColors>;
 }
 
 export function CellDiagram(props: CellDiagramProps) {
-    const { organization, project, previewMode } = props;
+    const { organization, project, previewMode, mode, colors } = props;
 
     return (
-        <Container className={previewMode ? "preview-mode" : ""}>
-            {organization ? (
-                <OrgDiagram organization={organization} {...props} />
-            ) : project ? (
-                <ProjectDiagram project={project} {...props} previewMode={previewMode} />
-            ) : (
-                <PromptScreen userMessage={"Organization or Project model not provided."} />
-            )}
-        </Container>
+        <CellDiagramThemeProvider mode={mode} colors={colors}>
+            <Container className={previewMode ? "preview-mode" : ""}>
+                {organization ? (
+                    <OrgDiagram organization={organization} {...props} />
+                ) : project ? (
+                    <ProjectDiagram project={project} {...props} previewMode={previewMode} />
+                ) : (
+                    <PromptScreen userMessage={"Organization or Project model not provided."} />
+                )}
+            </Container>
+        </CellDiagramThemeProvider>
     );
 }

--- a/src/components/Cell/CellLink/CellLinkWidget.tsx
+++ b/src/components/Cell/CellLink/CellLinkWidget.tsx
@@ -1,7 +1,7 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
 import { DiagramEngine, PortModelAlignment } from "@projectstorm/react-diagrams";
 import { CellLinkModel } from "./CellLinkModel";
-import { CELL_LINK, Colors, LINK_WIDTH, WarningIcon } from "../../../resources";
+import { CELL_LINK, LINK_WIDTH, WarningIcon } from "../../../resources";
 import { ObservationLabel } from "../../ObservationLabel/ObservationLabel";
 import { TooltipLabel } from "../../TooltipLabel/TooltipLabel";
 import { DiagramContext } from "../../DiagramContext/DiagramContext";
@@ -10,36 +10,44 @@ import { SharedLink } from "../../SharedLink/SharedLink";
 import Popper from "@mui/material/Popper";
 import Box from "@mui/material/Box";
 import { CellBounds } from "../CellNode/CellModel";
+import { useColors } from "../../../theme";
 
 interface WidgetProps {
     engine: DiagramEngine;
     link: CellLinkModel;
 }
 
-const tooltipPopOverStyle = {
-    backgroundColor: Colors.SURFACE,
-    border: `1px solid ${Colors.SECONDARY}`,
-    padding: "10px",
-    borderRadius: "5px",
-    display: "flex",
-    flexDirection: "column",
-    maxWidth: "280px",
-    gap: "8px",
-    pointerEvents: "none",
-};
-
-const observabilityPopOverStyle = {
-    backgroundColor: Colors.SURFACE,
-    border: `1px solid ${Colors.SECONDARY}`,
-    padding: "10px",
-    borderRadius: "5px",
-    display: "flex",
-    flexDirection: "column",
-    pointerEvents: "none",
-};
-
 export function CellLinkWidget(props: WidgetProps) {
     const { link } = props;
+    const colors = useColors();
+
+    const tooltipPopOverStyle = useMemo(
+        () => ({
+            backgroundColor: colors.SURFACE,
+            border: `1px solid ${colors.SECONDARY}`,
+            padding: "10px",
+            borderRadius: "5px",
+            display: "flex",
+            flexDirection: "column" as const,
+            maxWidth: "280px",
+            gap: "8px",
+            pointerEvents: "none" as const,
+        }),
+        [colors],
+    );
+
+    const observabilityPopOverStyle = useMemo(
+        () => ({
+            backgroundColor: colors.SURFACE,
+            border: `1px solid ${colors.SECONDARY}`,
+            padding: "10px",
+            borderRadius: "5px",
+            display: "flex",
+            flexDirection: "column" as const,
+            pointerEvents: "none" as const,
+        }),
+        [colors],
+    );
 
     const {
         diagramLayers: { hasLayer },
@@ -131,19 +139,19 @@ export function CellLinkWidget(props: WidgetProps) {
 
     const strokeColor = () => {
         if (isSelected && (hasArchitectureLayer || hasDiffLayer)) {
-            return Colors.SECONDARY;
+            return colors.SECONDARY;
         }
         if (hasDiffLayer && link.observationOnly) {
-            return Colors.ERROR;
+            return colors.ERROR;
         }
         if (hasObservabilityLayer && link.observations?.length > 0) {
-            return Colors.PRIMARY;
+            return colors.PRIMARY;
         }
         if (hideLink) {
             return "transparent";
         }
 
-        return Colors.ON_SURFACE_VARIANT;
+        return colors.ON_SURFACE_VARIANT;
     };
 
     const strokeDash = () => {

--- a/src/components/Cell/CellNode/styles.ts
+++ b/src/components/Cell/CellNode/styles.ts
@@ -17,7 +17,7 @@
  */
 
 import styled from "@emotion/styled";
-import { CIRCLE_WIDTH, Colors, DOT_WIDTH, CELL_LINE_MIN_WIDTH } from "../../../resources";
+import { CIRCLE_WIDTH, DOT_WIDTH, CELL_LINE_MIN_WIDTH } from "../../../resources";
 
 interface StyleProps {
     isSelected?: boolean;
@@ -52,7 +52,7 @@ export const CellNode = styled.div<StyleProps>`
     }
 
     #mainCell path {
-        stroke: ${Colors.OUTLINE};
+        stroke: ${({ theme }) => theme.colors.OUTLINE};
         stroke-width: ${(props: StyleProps) => props.borderWidth};
         fill: none;
         pointer-events: none;
@@ -69,24 +69,24 @@ export const Circle = styled.div<ElementProps>`
     width: ${CIRCLE_WIDTH}px;
     height: ${CIRCLE_WIDTH}px;
     border-radius: 50%;
-    border: ${CELL_LINE_MIN_WIDTH}px solid ${Colors.OUTLINE};
+    border: ${CELL_LINE_MIN_WIDTH}px solid ${({ theme }) => theme.colors.OUTLINE};
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    background-color: ${Colors.SURFACE};
+    background-color: ${({ theme }) => theme.colors.SURFACE};
 `;
 
 export const Dot = styled.div<any>`
     width: ${DOT_WIDTH}px;
     height: ${DOT_WIDTH}px;
     border-radius: 50%;
-    border: ${CELL_LINE_MIN_WIDTH}px solid ${Colors.OUTLINE};
+    border: ${CELL_LINE_MIN_WIDTH}px solid ${({ theme }) => theme.colors.OUTLINE};
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    background-color: ${Colors.SURFACE_DIM};
+    background-color: ${({ theme }) => theme.colors.SURFACE_DIM};
 `;
 
 export const TopPortCircle: React.FC<any> = styled(Circle)`
@@ -141,7 +141,7 @@ export const PortLabel: React.FC<any> = styled.div`
     flex-direction: column;
     align-items: flex-start;
     font-family: "GilmerMedium";
-    color: ${Colors.OUTLINE};
+    color: ${({ theme }) => theme.colors.OUTLINE};
     font-size: 20px;
     span {
         text-align: left;
@@ -180,14 +180,14 @@ export const BottomPortLabel: React.FC<any> = styled(PortLabel)`
 export const IconWrapper: React.FC<any> = styled.div`
     height: 32px;
     width: 32px;
-    color: ${Colors.OUTLINE};
+    color: ${({ theme }) => theme.colors.OUTLINE};
     font-size: 28px;
 `;
 
 export const TopIconWrapper: React.FC<any> = styled.div`
     height: 32px;
     width: 32px;
-    color: ${Colors.OUTLINE};
+    color: ${({ theme }) => theme.colors.OUTLINE};
     font-size: 28px;
     transform: rotate(90deg);
 `;

--- a/src/components/Component/ComponentLink/ComponentLinkWidget.tsx
+++ b/src/components/Component/ComponentLink/ComponentLinkWidget.tsx
@@ -16,10 +16,10 @@
  * under the License.
  */
 
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
 import { DiagramEngine } from "@projectstorm/react-diagrams";
 import { ComponentLinkModel } from "./ComponentLinkModel";
-import { COMPONENT_LINK, Colors, LINK_WIDTH, WarningIcon } from "../../../resources";
+import { COMPONENT_LINK, LINK_WIDTH, WarningIcon } from "../../../resources";
 import { ObservationLabel } from "../../ObservationLabel/ObservationLabel";
 import { TooltipLabel } from "../../TooltipLabel/TooltipLabel";
 import { DiagramContext } from "../../DiagramContext/DiagramContext";
@@ -27,36 +27,44 @@ import { DiagramLayer } from "../../../types";
 import { SharedLink } from "../../SharedLink/SharedLink";
 import Popper from "@mui/material/Popper";
 import Box from "@mui/material/Box";
+import { useColors } from "../../../theme";
 
 interface WidgetProps {
     engine: DiagramEngine;
     link: ComponentLinkModel;
 }
 
-const tooltipPopOverStyle = {
-    backgroundColor: Colors.SURFACE,
-    border: `1px solid ${Colors.SECONDARY}`,
-    padding: "10px",
-    borderRadius: "5px",
-    display: "flex",
-    flexDirection: "column",
-    maxWidth: "280px",
-    gap: "8px",
-    pointerEvents: "none",
-};
-
-const observabilityPopOverStyle = {
-    backgroundColor: Colors.SURFACE,
-    border: `1px solid ${Colors.SECONDARY}`,
-    padding: "10px",
-    borderRadius: "5px",
-    display: "flex",
-    flexDirection: "column",
-    pointerEvents: "none",
-};
-
 export function ComponentLinkWidget(props: WidgetProps) {
     const { link } = props;
+    const colors = useColors();
+
+    const tooltipPopOverStyle = useMemo(
+        () => ({
+            backgroundColor: colors.SURFACE,
+            border: `1px solid ${colors.SECONDARY}`,
+            padding: "10px",
+            borderRadius: "5px",
+            display: "flex",
+            flexDirection: "column" as const,
+            maxWidth: "280px",
+            gap: "8px",
+            pointerEvents: "none" as const,
+        }),
+        [colors],
+    );
+
+    const observabilityPopOverStyle = useMemo(
+        () => ({
+            backgroundColor: colors.SURFACE,
+            border: `1px solid ${colors.SECONDARY}`,
+            padding: "10px",
+            borderRadius: "5px",
+            display: "flex",
+            flexDirection: "column" as const,
+            pointerEvents: "none" as const,
+        }),
+        [colors],
+    );
 
     const {
         diagramLayers: { hasLayer },
@@ -139,19 +147,19 @@ export function ComponentLinkWidget(props: WidgetProps) {
 
     const strokeColor = () => {
         if (isSelected && (hasArchitectureLayer || hasDiffLayer)) {
-            return Colors.SECONDARY;
+            return colors.SECONDARY;
         }
         if (hasDiffLayer && link.observationOnly) {
-            return Colors.ERROR;
+            return colors.ERROR;
         }
         if (hasObservabilityLayer && link.observations?.length > 0) {
-            return Colors.PRIMARY;
+            return colors.PRIMARY;
         }
         if (hideLink) {
             return "transparent";
         }
 
-        return Colors.ON_SURFACE_VARIANT;
+        return colors.ON_SURFACE_VARIANT;
     };
 
     const strokeDash = () => {

--- a/src/components/Component/ComponentNode/styles.ts
+++ b/src/components/Component/ComponentNode/styles.ts
@@ -17,13 +17,13 @@
  */
 
 import styled from "@emotion/styled";
-import { COMPONENT_CIRCLE_WIDTH, Colors, ICON_SCALE, LABEL_FONT_SIZE, LABEL_MAX_WIDTH } from "../../../resources";
+import { COMPONENT_CIRCLE_WIDTH, ICON_SCALE, LABEL_FONT_SIZE, LABEL_MAX_WIDTH } from "../../../resources";
 
 interface ComponentNodeStyleProps {
     previewMode: boolean;
 }
 export const ComponentNode = styled.div<ComponentNodeStyleProps>`
-    color: ${Colors.ON_SURFACE_VARIANT};
+    color: ${({ theme }) => theme.colors.ON_SURFACE_VARIANT};
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -44,11 +44,11 @@ interface ComponentHeadStyleProps {
     disabled: boolean;
 }
 export const ComponentHead = styled.div<ComponentHeadStyleProps>`
-    background-color: ${(props: ComponentHeadStyleProps) =>
-        !props.disabled && props.isSelected ? Colors.SECONDARY_CONTAINER : Colors.SURFACE};
-    border: ${(props: ComponentHeadStyleProps) =>
-        `${props.borderWidth}px solid ${
-            props.disabled ? Colors.SURFACE_DIM : props.isSelected ? Colors.SECONDARY : Colors.PRIMARY
+    background-color: ${({ theme, disabled, isSelected }) =>
+        !disabled && isSelected ? theme.colors.SECONDARY_CONTAINER : theme.colors.SURFACE};
+    border: ${({ theme, borderWidth, disabled, isSelected }) =>
+        `${borderWidth}px solid ${
+            disabled ? theme.colors.SURFACE_DIM : isSelected ? theme.colors.SECONDARY : theme.colors.PRIMARY
         }`};
     border-radius: 50%;
     height: ${COMPONENT_CIRCLE_WIDTH}px;
@@ -64,7 +64,7 @@ export const ComponentHead = styled.div<ComponentHeadStyleProps>`
 `;
 
 export const ComponentKind = styled.div`
-    background-color: ${Colors.SURFACE};
+    background-color: ${({ theme }) => theme.colors.SURFACE};
     border-radius: 50%;
 
     height: ${COMPONENT_CIRCLE_WIDTH / 3}px;
@@ -92,7 +92,7 @@ export const ComponentName = styled.span<ComponentNameStyleProps>`
     text-overflow: ellipsis;
     text-align: center;
     max-width: ${LABEL_MAX_WIDTH}px;
-    color: ${(props: IconWrapperStyleProps) => (props.disabled ? Colors.SURFACE_DIM : Colors.OUTLINE)};
+    color: ${({ theme, disabled }) => (disabled ? theme.colors.SURFACE_DIM : theme.colors.OUTLINE)};
 `;
 
 interface IconWrapperStyleProps {
@@ -106,14 +106,14 @@ export const IconWrapper = styled.div<IconWrapperStyleProps>`
     height: 100%;
     width: 100%;
 
-    color: ${(props: IconWrapperStyleProps) => (props.disabled ? Colors.SURFACE_DIM : Colors.PRIMARY)};
+    color: ${({ theme, disabled }) => (disabled ? theme.colors.SURFACE_DIM : theme.colors.PRIMARY)};
     font-size: 32px;
 
     svg {
-        fill: ${(props: IconWrapperStyleProps) => (props.disabled ? Colors.SURFACE_DIM : Colors.PRIMARY)};
+        fill: ${({ theme, disabled }) => (disabled ? theme.colors.SURFACE_DIM : theme.colors.PRIMARY)};
         height: 32px;
         width: 32px;
-        transform: ${(props: IconWrapperStyleProps) => (props.previewMode ? `scale(${ICON_SCALE.PREVIEW})` : "none")};
+        transform: ${({ previewMode }) => (previewMode ? `scale(${ICON_SCALE.PREVIEW})` : "none")};
     }
 `;
 

--- a/src/components/Connection/ConnectionNode/styles.ts
+++ b/src/components/Connection/ConnectionNode/styles.ts
@@ -17,7 +17,7 @@
  */
 
 import styled from "@emotion/styled";
-import { CIRCLE_WIDTH, Colors, ICON_SCALE, LABEL_FONT_SIZE, LABEL_MAX_WIDTH } from "../../../resources";
+import { CIRCLE_WIDTH, ICON_SCALE, LABEL_FONT_SIZE, LABEL_MAX_WIDTH } from "../../../resources";
 import { Orientation } from "./ConnectionModel";
 
 interface StyleProps {
@@ -32,7 +32,7 @@ interface StyleProps {
 }
 
 export const ConnectionNode = styled.div<StyleProps>`
-    color: ${Colors.ON_SURFACE_VARIANT};
+    color: ${({ theme }) => theme.colors.ON_SURFACE_VARIANT};
     display: flex;
     flex-direction: ${(props: StyleProps) => (props.orientation === Orientation.VERTICAL ? "column" : "row")};
     align-items: center;
@@ -47,9 +47,12 @@ export const ConnectionNode = styled.div<StyleProps>`
 `;
 
 export const ConnectionHead = styled.div<StyleProps>`
-    background-color: ${(props: StyleProps) => (props.isSelected ? Colors.SECONDARY_CONTAINER : Colors.SURFACE)};
-    border: ${(props: StyleProps) =>
-        `${props.borderWidth}px solid ${props.isSelected ? Colors.SECONDARY : props.isFocused ? Colors.SECONDARY : Colors.OUTLINE}`};
+    background-color: ${({ theme, isSelected }) =>
+        isSelected ? theme.colors.SECONDARY_CONTAINER : theme.colors.SURFACE};
+    border: ${({ theme, borderWidth, isSelected, isFocused }) =>
+        `${borderWidth}px solid ${
+            isSelected ? theme.colors.SECONDARY : isFocused ? theme.colors.SECONDARY : theme.colors.OUTLINE
+        }`};
     border-radius: 50%;
     height: ${CIRCLE_WIDTH}px;
     width: ${CIRCLE_WIDTH}px;
@@ -68,12 +71,13 @@ export const ConnectionName = styled.span<StyleProps>`
 
 interface IconWrapperStyleProps {
     previewMode: boolean;
+    isSelected?: boolean;
 }
 export const IconWrapper = styled.div<IconWrapperStyleProps>`
     height: 32px;
     width: 32px;
     svg {
-        fill: ${(props: StyleProps) => (props.isSelected ? Colors.SECONDARY : Colors.OUTLINE)};
-        transform: ${(props: IconWrapperStyleProps) => (props.previewMode ? `scale(${ICON_SCALE.PREVIEW})` : "none")};
+        fill: ${({ theme, isSelected }) => (isSelected ? theme.colors.SECONDARY : theme.colors.OUTLINE)};
+        transform: ${({ previewMode }) => (previewMode ? `scale(${ICON_SCALE.PREVIEW})` : "none")};
     }
 `;

--- a/src/components/Controls/ControlButtons/ControlButton.tsx
+++ b/src/components/Controls/ControlButtons/ControlButton.tsx
@@ -18,8 +18,7 @@
 
 import React, { ReactNode } from "react";
 import Tooltip from "@mui/material/Tooltip";
-import IconButton from "@mui/material/IconButton";
-import { useStyles } from "./style";
+import { ControlIconButton } from "./style";
 
 interface ControlButtonProps {
     children: ReactNode;
@@ -30,7 +29,6 @@ interface ControlButtonProps {
 
 export function CanvasControlButton(props: ControlButtonProps) {
     const { children, onClick, tooltipTitle, tooltipPlacement = "left-end" } = props;
-    const styles = useStyles();
 
     return (
         <Tooltip
@@ -58,8 +56,7 @@ export function CanvasControlButton(props: ControlButtonProps) {
                 ],
             }}
         >
-            <IconButton
-                className={styles.controlButton}
+            <ControlIconButton
                 size="small"
                 onClick={onClick}
                 sx={{
@@ -67,7 +64,7 @@ export function CanvasControlButton(props: ControlButtonProps) {
                 }}
             >
                 {children}
-            </IconButton>
+            </ControlIconButton>
         </Tooltip>
     );
 }

--- a/src/components/Controls/ControlButtons/style.ts
+++ b/src/components/Controls/ControlButtons/style.ts
@@ -16,20 +16,24 @@
  * under the License.
  */
 
-import { createStyles, makeStyles } from "@material-ui/core/styles";
+import styled from "@emotion/styled";
+import IconButton from "@mui/material/IconButton";
 
-export const useStyles = makeStyles(() =>
-    createStyles({
-        controlButton: {
-            backgroundColor: "white !important",
-            border: "1px solid #E0E2E9 !important", 
-            borderRadius: "2px !important",
-            height: "32px !important",
-            width: "32px !important",
-            "& svg": {
-                height: "20px",
-                width: "20px"
-            }
-        }
-    })
-);
+/**
+ * Themed IconButton used by `CanvasControlButton`. Background and border are
+ * pulled from the active cell-diagram theme so the canvas controls match
+ * dark mode automatically.
+ */
+export const ControlIconButton = styled(IconButton)`
+    background-color: ${({ theme }) => theme.colors.SURFACE_BRIGHT} !important;
+    border: 1px solid ${({ theme }) => theme.colors.SURFACE_DIM} !important;
+    border-radius: 2px !important;
+    height: 32px !important;
+    width: 32px !important;
+    color: ${({ theme }) => theme.colors.ON_SURFACE_VARIANT};
+
+    & svg {
+        height: 20px;
+        width: 20px;
+    }
+`;

--- a/src/components/Controls/DiagramLayers.tsx
+++ b/src/components/Controls/DiagramLayers.tsx
@@ -20,7 +20,7 @@ import React, { useEffect, useRef, useState } from "react";
 import styled from "@emotion/styled";
 import gsap from "gsap";
 import { useDiagramContext } from "../DiagramContext/DiagramContext";
-import { Colors, DiagramIcon, DiffIcon, LayersIcon, ObservationIcon } from "../../resources";
+import { DiagramIcon, DiffIcon, LayersIcon, ObservationIcon } from "../../resources";
 import { DiagramLayer, DiagramLayerTooltips } from "../../types";
 import { CanvasControlButton } from "./ControlButtons/ControlButton";
 import { LayerButton } from "./LayerButton";
@@ -43,17 +43,18 @@ export const LayersPanel: React.FC<any> = styled.div`
     align-items: center;
     gap: 8px;
     padding: 6px 6px 4px;
-    background-color: ${Colors.SURFACE_BRIGHT};
-    border: 1px solid ${Colors.SURFACE_DIM};
+    background-color: ${({ theme }) => theme.colors.SURFACE_BRIGHT};
+    border: 1px solid ${({ theme }) => theme.colors.SURFACE_DIM};
 `;
 
 export const MainButton: React.FC<any> = styled.div`
-    border: 1px solid ${Colors.SURFACE_DIM};
+    border: 1px solid ${({ theme }) => theme.colors.SURFACE_DIM};
     width: 34px;
     height: 34px;
     border-radius: 2px;
-    color: ${(props) => (props.selected ? Colors.PRIMARY : Colors.OUTLINE_VARIANT)};
-    background-color: ${Colors.SURFACE_BRIGHT};
+    color: ${({ theme, selected }: { theme: any; selected?: boolean }) =>
+        selected ? theme.colors.PRIMARY : theme.colors.OUTLINE_VARIANT};
+    background-color: ${({ theme }) => theme.colors.SURFACE_BRIGHT};
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -62,7 +63,7 @@ export const MainButton: React.FC<any> = styled.div`
     padding: 5px;
     cursor: pointer;
     &:active {
-        background-color: ${Colors.SURFACE_DIM};
+        background-color: ${({ theme }) => theme.colors.SURFACE_DIM};
     }
 `;
 

--- a/src/components/Controls/DiagramLegend.tsx
+++ b/src/components/Controls/DiagramLegend.tsx
@@ -19,9 +19,9 @@
 import React, { useContext, useEffect, useRef } from "react";
 import styled from "@emotion/styled";
 import gsap from "gsap";
-import { Colors } from "../../resources";
 import { DiagramContext } from "../DiagramContext/DiagramContext";
 import { DiagramLayer } from "../../types";
+import { useColors } from "../../theme";
 
 export const DiagramLegendPanel: React.FC<any> = styled.div`
     position: absolute;
@@ -36,8 +36,8 @@ export const DiagramLegendPanel: React.FC<any> = styled.div`
 
     padding: 8px;
 
-    background-color: ${Colors.SURFACE};
-    border: 1px solid ${Colors.SURFACE_DIM};
+    background-color: ${({ theme }) => theme.colors.SURFACE};
+    border: 1px solid ${({ theme }) => theme.colors.SURFACE_DIM};
 `;
 
 export const LegendRow: React.FC<any> = styled.div`
@@ -50,7 +50,7 @@ export const LegendRow: React.FC<any> = styled.div`
 export const Text: React.FC<any> = styled.div`
     font-size: 12px;
     user-select: none;
-    color: ${Colors.ON_SURFACE_VARIANT};
+    color: ${({ theme }) => theme.colors.ON_SURFACE_VARIANT};
 `;
 
 interface DiagramLegendProps {
@@ -59,6 +59,10 @@ interface DiagramLegendProps {
 
 export function DiagramLegend(props: DiagramLegendProps) {
     const { animation = true } = props;
+    const colors = useColors();
+    // The "hsl(0, 0%, 30%)" stroke on the legend's svg <g> is a backdrop
+    // line that gets overdrawn by the actual stroke color below; we leave
+    // it as-is to preserve the original visual.
 
     const {
         diagramLayers: { hasLayer },
@@ -96,7 +100,7 @@ export function DiagramLegend(props: DiagramLegendProps) {
                                 x2="200"
                                 y2="25"
                                 markerEnd={hasObservabilityLayer ? "" : "url(#solidLinkArrow)"}
-                                stroke={hasObservabilityLayer ? Colors.PRIMARY : Colors.ON_SURFACE_VARIANT}
+                                stroke={hasObservabilityLayer ? colors.PRIMARY : colors.ON_SURFACE_VARIANT}
                             ></line>
                         </g>
                         <defs>
@@ -110,7 +114,7 @@ export function DiagramLegend(props: DiagramLegendProps) {
                                 viewBox="0 0 6 6"
                                 orient="auto"
                             >
-                                <polygon points="0,6 0,0 5,3" fill={hasObservabilityLayer ? Colors.PRIMARY : Colors.ON_SURFACE_VARIANT}></polygon>
+                                <polygon points="0,6 0,0 5,3" fill={hasObservabilityLayer ? colors.PRIMARY : colors.ON_SURFACE_VARIANT}></polygon>
                             </marker>
                         </defs>
                     </svg>
@@ -129,7 +133,7 @@ export function DiagramLegend(props: DiagramLegendProps) {
                                 x2="200"
                                 y2="25"
                                 markerEnd={hasObservabilityLayer ? "" : "url(#solidLinkArrow)"}
-                                stroke={Colors.ON_SURFACE_VARIANT}
+                                stroke={colors.ON_SURFACE_VARIANT}
                             ></line>
                         </g>
                         <defs>
@@ -143,7 +147,7 @@ export function DiagramLegend(props: DiagramLegendProps) {
                                 viewBox="0 0 6 6"
                                 orient="auto"
                             >
-                                <polygon points="0,6 0,0 5,3" fill={Colors.ON_SURFACE_VARIANT}></polygon>
+                                <polygon points="0,6 0,0 5,3" fill={colors.ON_SURFACE_VARIANT}></polygon>
                             </marker>
                         </defs>
                     </svg>
@@ -154,7 +158,7 @@ export function DiagramLegend(props: DiagramLegendProps) {
                 <LegendRow>
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 50" width={50} height={10}>
                         <g strokeWidth={10} stroke="hsl(0, 0%, 30%)" fill="none">
-                            <line x1={0} y1={25} x2={200} y2={25} markerEnd={hasObservabilityLayer ? "" : "url(#redLinkArrow)"} stroke={Colors.ERROR}></line>
+                            <line x1={0} y1={25} x2={200} y2={25} markerEnd={hasObservabilityLayer ? "" : "url(#redLinkArrow)"} stroke={colors.ERROR}></line>
                         </g>
                         <defs>
                             <marker
@@ -167,7 +171,7 @@ export function DiagramLegend(props: DiagramLegendProps) {
                                 viewBox="0 0 6 6"
                                 orient="auto"
                             >
-                                <polygon points="0,6 0,0 5,3" fill={Colors.ERROR}></polygon>
+                                <polygon points="0,6 0,0 5,3" fill={colors.ERROR}></polygon>
                             </marker>
                         </defs>
                     </svg>
@@ -198,7 +202,7 @@ export function DiagramLegend(props: DiagramLegendProps) {
                                 viewBox="0 0 6 6"
                                 orient="auto"
                             >
-                                <polygon points="0,6 0,0 5,3" fill={Colors.ON_SURFACE_VARIANT}></polygon>
+                                <polygon points="0,6 0,0 5,3" fill={colors.ON_SURFACE_VARIANT}></polygon>
                             </marker>
                         </defs>
                     </svg>

--- a/src/components/Controls/LayerButton.tsx
+++ b/src/components/Controls/LayerButton.tsx
@@ -18,7 +18,6 @@
 
 import React from "react";
 import styled from "@emotion/styled";
-import { Colors } from "../../resources";
 import { ReactNode } from "react";
 import { Tooltip } from "@mui/material";
 
@@ -34,22 +33,22 @@ const Button = styled.div<ButtonProps>`
     justify-content: space-between;
     font-size: 12px;
     cursor: ${(props) => (props.clickable ? "pointer" : "not-allowed")};
-    color: ${(props) => (props.selected ? Colors.PRIMARY : Colors.ON_SURFACE_VARIANT)};
+    color: ${({ theme, selected }) => (selected ? theme.colors.PRIMARY : theme.colors.ON_SURFACE_VARIANT)};
     user-select: none;
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
     div {
-        border: 1px solid ${(props) => (props.selected ? Colors.PRIMARY : Colors.SURFACE_DIM)};
-        background-color: ${Colors.SURFACE};
-        color: ${(props) => (props.selected ? Colors.PRIMARY : Colors.OUTLINE_VARIANT)};
+        border: 1px solid ${({ theme, selected }) => (selected ? theme.colors.PRIMARY : theme.colors.SURFACE_DIM)};
+        background-color: ${({ theme }) => theme.colors.SURFACE};
+        color: ${({ theme, selected }) => (selected ? theme.colors.PRIMARY : theme.colors.OUTLINE_VARIANT)};
     }
     &:hover {
-        color: ${Colors.PRIMARY};
+        color: ${({ theme }) => theme.colors.PRIMARY};
     }
     &:hover div {
-        border: 1px solid ${Colors.PRIMARY};
-        color: ${Colors.PRIMARY};
+        border: 1px solid ${({ theme }) => theme.colors.PRIMARY};
+        color: ${({ theme }) => theme.colors.PRIMARY};
     }
 `;
 

--- a/src/components/External/ExternalLink/ExternalLinkWidget.tsx
+++ b/src/components/External/ExternalLink/ExternalLinkWidget.tsx
@@ -19,8 +19,9 @@
 import React, { useContext, useEffect, useState } from "react";
 import { DiagramEngine } from "@projectstorm/react-diagrams";
 import { ExternalLinkModel } from "./ExternalLinkModel";
-import { Colors, EXTERNAL_LINK, LINK_WIDTH } from "../../../resources";
+import { EXTERNAL_LINK, LINK_WIDTH } from "../../../resources";
 import { DiagramContext } from "../../DiagramContext/DiagramContext";
+import { useColors } from "../../../theme";
 
 interface WidgetProps {
     engine: DiagramEngine;
@@ -29,6 +30,7 @@ interface WidgetProps {
 
 export function ExternalLinkWidget(props: WidgetProps) {
     const { link } = props;
+    const colors = useColors();
 
     const [isSelected, setIsSelected] = useState<boolean>(false);
     const { previewMode } = useContext(DiagramContext);
@@ -66,14 +68,14 @@ export function ExternalLinkWidget(props: WidgetProps) {
                     viewBox="0 0 6 6"
                     orient="auto"
                 >
-                    <polygon points="0,6 0,0 5,3" fill={isSelected ? Colors.SECONDARY : Colors.OUTLINE}></polygon>
+                    <polygon points="0,6 0,0 5,3" fill={isSelected ? colors.SECONDARY : colors.OUTLINE}></polygon>
                 </marker>
             </defs>
             <path
                 id={link.getID()}
                 d={link.withRightOffset ? link.getCurvePathWithOffset() : link.getCurvePath()}
                 fill={"none"}
-                stroke={isSelected ? Colors.SECONDARY : Colors.OUTLINE}
+                stroke={isSelected ? colors.SECONDARY : colors.OUTLINE}
                 strokeWidth={previewMode ? LINK_WIDTH.PREVIEW : LINK_WIDTH.DEFAULT}
                 markerEnd={"url(#" + link.getLinkArrowId() + ")"}
             />

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -18,13 +18,12 @@
 
 import React from "react";
 import styled from "@emotion/styled";
-import { Colors } from "../../resources";
 
 interface HeaderProps {}
 
 const HeaderContainer = styled.div`
     align-items: center;
-    color: ${Colors.ON_SURFACE_VARIANT};
+    color: ${({ theme }) => theme.colors.ON_SURFACE_VARIANT};
     display: flex;
     flex-direction: row;
     font-family: GilmerBold;

--- a/src/components/MoreVertMenu/MoreVertMenu.tsx
+++ b/src/components/MoreVertMenu/MoreVertMenu.tsx
@@ -21,13 +21,12 @@ import styled from "@emotion/styled";
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
-import { Colors } from "../../resources";
 import { Component } from "../../types";
 import { MoreVertMenuItem } from "../../types";
 
 const IconStyles = styled.button`
     position: absolute;
-    background-color: ${Colors.SURFACE};
+    background-color: ${({ theme }) => theme.colors.SURFACE};
     margin-left: 68px;
     margin-bottom: 58px;
     width: 28px;
@@ -38,7 +37,7 @@ const IconStyles = styled.button`
     justify-content: center;
     align-items: center;
     line-height: 0;
-    border: 3px solid ${Colors.SURFACE_DIM};
+    border: 3px solid ${({ theme }) => theme.colors.SURFACE_DIM};
     transition: "transform 0.3s ease-in-out";
     cursor: pointer;
 `;

--- a/src/components/ObservationLabel/ObservationLabel.tsx
+++ b/src/components/ObservationLabel/ObservationLabel.tsx
@@ -18,7 +18,6 @@
 
 import React from "react";
 import styled from "@emotion/styled";
-import { Colors } from "../../resources";
 import { Observations } from "../../types";
 import { useDiagramContext } from "../DiagramContext/DiagramContext";
 
@@ -45,7 +44,7 @@ const TopTableHeader = styled(TableHeader)`
 
 const TableData = styled.td`
     padding: 2px 2px 2px 8px;
-    color: ${Colors.PRIMARY};
+    color: ${({ theme }) => theme.colors.PRIMARY};
     text-align: right;
     font-family: "GilmerRegular";
 `;

--- a/src/components/OverlayLoader/OverlayLayerWidget.tsx
+++ b/src/components/OverlayLoader/OverlayLayerWidget.tsx
@@ -35,9 +35,9 @@ const Container = styled.div`
 	justify-content: center;
 	height: 100%;
 	width: 100%;
-	background-image: radial-gradient(${Colors.SURFACE_CONTAINER} 10%, transparent 0px);
+	background-image: radial-gradient(${({ theme }) => theme.colors.SURFACE_CONTAINER} 10%, transparent 0px);
     background-size: 16px 16px;
-    background-color: ${Colors.SURFACE_BRIGHT};
+    background-color: ${({ theme }) => theme.colors.SURFACE_BRIGHT};
 `;
 
 export class OverlayLayerWidget extends React.Component<NodeLayerWidgetProps> {

--- a/src/components/Project/ProjectLink/ProjectLinkWidget.tsx
+++ b/src/components/Project/ProjectLink/ProjectLinkWidget.tsx
@@ -19,8 +19,9 @@
 import React, { useEffect, useState } from "react";
 import { DiagramEngine } from "@projectstorm/react-diagrams";
 import { ProjectLinkModel } from "./ProjectLinkModel";
-import { Colors, PROJECT_LINK } from "../../../resources";
+import { PROJECT_LINK } from "../../../resources";
 import { SharedLink } from "../../SharedLink/SharedLink";
+import { useColors } from "../../../theme";
 
 interface WidgetProps {
     engine: DiagramEngine;
@@ -29,6 +30,7 @@ interface WidgetProps {
 
 export function ProjectLinkWidget(props: WidgetProps) {
     const { link } = props;
+    const colors = useColors();
 
     const [isSelected, setIsSelected] = useState<boolean>(false);
 
@@ -66,10 +68,10 @@ export function ProjectLinkWidget(props: WidgetProps) {
 
     const strokeColor = () => {
         if (isSelected) {
-            return Colors.SECONDARY;
+            return colors.SECONDARY;
         }
 
-        return Colors.ON_SURFACE_VARIANT;
+        return colors.ON_SURFACE_VARIANT;
     };
 
     // const midPoint = link.getMidPoint();

--- a/src/components/Project/ProjectNode/ProjectWidget.tsx
+++ b/src/components/Project/ProjectNode/ProjectWidget.tsx
@@ -25,7 +25,7 @@ import { ProjectModel } from "./ProjectModel";
 import { ProjectHeadWidget } from "./ProjectHeadWidget/ProjectHeadWidget";
 import { ProjectName, ProjectNode } from "./styles";
 import { DiagramContext } from "../../DiagramContext/DiagramContext";
-import { Colors } from "../../../resources";
+import { useColors } from "../../../theme";
 
 interface ProjectWidgetProps {
     node: ProjectModel;
@@ -34,6 +34,7 @@ interface ProjectWidgetProps {
 
 export function ProjectWidget(props: ProjectWidgetProps) {
     const { node, engine } = props;
+    const colors = useColors();
     const { selectedNodeId, focusedNodeId, componentMenu, onComponentDoubleClick } = useContext(DiagramContext);
     const [isHovered, setIsHovered] = useState<boolean>(false);
     const headPorts = useRef<PortModel[]>([]);
@@ -94,7 +95,7 @@ export function ProjectWidget(props: ProjectWidgetProps) {
                 <Box sx={{ position: 'absolute', top: '26px', padding: '8px', cursor: 'pointer' }} onClick={handleOnWidgetDoubleClick}>
                     <Fade in={isHovered} timeout={350}>
                         <Tooltip title="View Project" placement="bottom" enterNextDelay={1000}>
-                            <OpenInNewRoundedIcon sx={{ color: Colors.OUTLINE_VARIANT, fontSize: 20 }} />
+                            <OpenInNewRoundedIcon sx={{ color: colors.OUTLINE_VARIANT, fontSize: 20 }} />
                         </Tooltip>
                     </Fade>
                 </Box>

--- a/src/components/Project/ProjectNode/styles.ts
+++ b/src/components/Project/ProjectNode/styles.ts
@@ -17,9 +17,7 @@
  */
 
 import styled from "@emotion/styled";
-import { Colors, LABEL_FONT_SIZE, LABEL_MAX_WIDTH } from "../../../resources";
-
-const PRIMARY_HOVER: string = "#2c09ed";
+import { LABEL_FONT_SIZE, LABEL_MAX_WIDTH } from "../../../resources";
 
 interface StyleProps {
     isAnonymous: boolean;
@@ -32,7 +30,7 @@ interface StyleProps {
 }
 
 export const ProjectNode = styled.div<any>`
-    color: ${Colors.ON_SURFACE_VARIANT};
+    color: ${({ theme }) => theme.colors.ON_SURFACE_VARIANT};
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -76,10 +74,10 @@ export const ProjectCellNode = styled.div<ProjectNodeStyleProps>`
     }
 
     #mainCell path {
-        stroke: ${(props: ProjectNodeStyleProps) => (props.isSelected ? Colors.SECONDARY : Colors.ON_SURFACE)};
+        stroke: ${({ theme, isSelected }) => (isSelected ? theme.colors.SECONDARY : theme.colors.ON_SURFACE)};
         stroke-width: ${(props: ProjectNodeStyleProps) => props.borderWidth};
-        fill: ${(props: ProjectNodeStyleProps) =>
-            props.isSelected ? Colors.SECONDARY_CONTAINER : Colors.SURFACE};
+        fill: ${({ theme, isSelected }) =>
+            isSelected ? theme.colors.SECONDARY_CONTAINER : theme.colors.SURFACE};
         pointer-events: none;
     }
 `;
@@ -92,7 +90,8 @@ export const ProjectName: React.FC<any> = styled.span`
     text-align: center;
     /* max-width: ${LABEL_MAX_WIDTH}px; */
     &:hover {
-        color: ${(props: StyleProps) => (props.isClickable ? PRIMARY_HOVER : ``)};
+        color: ${({ theme, isClickable }: { theme: any; isClickable?: boolean }) =>
+            isClickable ? theme.colors.PRIMARY_HOVER : ``};
         text-decoration: ${(props: StyleProps) => (props.isClickable ? `underline` : ``)};
     }
 `;

--- a/src/components/Project/ProjectPort/styles.ts
+++ b/src/components/Project/ProjectPort/styles.ts
@@ -16,7 +16,6 @@
  * under the License.
  */
 
-import { Colors } from "../../../resources";
 import styled from "@emotion/styled";
 
 interface PortNodeStyleProps {
@@ -29,9 +28,10 @@ export const PortNode = styled.div<PortNodeStyleProps>`
   align-items: center;
   height: 10px;
   width: 10px;
-  background-color: ${(props: PortNodeStyleProps) =>
-    props.isSelected ? Colors.SECONDARY_CONTAINER : Colors.SURFACE_DIM};
-  border: 2px solid ${(props: PortNodeStyleProps) => (props.isSelected ? Colors.OUTLINE_VARIANT : Colors.OUTLINE)};
+  background-color: ${({ theme, isSelected }) =>
+    isSelected ? theme.colors.SECONDARY_CONTAINER : theme.colors.SURFACE_DIM};
+  border: 2px solid ${({ theme, isSelected }) =>
+    isSelected ? theme.colors.OUTLINE_VARIANT : theme.colors.OUTLINE};
   border-radius: 50%;
   margin: -6px 0;
 `;

--- a/src/components/PromptScreen/PromptScreen.tsx
+++ b/src/components/PromptScreen/PromptScreen.tsx
@@ -18,7 +18,6 @@
 
 import React from "react";
 import styled from "@emotion/styled";
-import { Colors } from "../../resources";
 
 const Container = styled.div`
     display: flex;
@@ -27,13 +26,13 @@ const Container = styled.div`
     justify-content: center;
     height: 100%;
     width: 100%;
-    background-image: radial-gradient(${Colors.SURFACE_CONTAINER} 10%, transparent 0px);
+    background-image: radial-gradient(${({ theme }) => theme.colors.SURFACE_CONTAINER} 10%, transparent 0px);
     background-size: 16px 16px;
-    background-color: ${Colors.SURFACE_BRIGHT};
+    background-color: ${({ theme }) => theme.colors.SURFACE_BRIGHT};
 `;
 
 const MassageBox = styled.h3`
-    color: ${Colors.ON_SURFACE_VARIANT};
+    color: ${({ theme }) => theme.colors.ON_SURFACE_VARIANT};
     font-family: GilmerRegular;
     font-size: 16px;
     padding: 10px;

--- a/src/resources/constants.ts
+++ b/src/resources/constants.ts
@@ -17,27 +17,18 @@
  */
 
 
-export enum Colors {    
-    PRIMARY = '#5567D5',
-    ON_PRIMARY = '#FFF',
-    PRIMARY_CONTAINER = '#F0F1FB',
-    
-    SECONDARY = '#ffaf4d',
-    ON_SECONDARY = '#FFF',
-    SECONDARY_CONTAINER = '#fffaf2', 
-    
-    SURFACE_BRIGHT = '#FFF',
-    SURFACE = '#F7F8FB',
-    SURFACE_DIM = '#CBCEDB',
-    SURFACE_CONTAINER = "#cfd1f3",
-    ON_SURFACE = '#000',
-    ON_SURFACE_VARIANT = '#40404B',
+/**
+ * Light-theme palette retained as a value export for callers that import
+ * `Colors` directly. The `<CellDiagram>` component now resolves colors at
+ * runtime through the theme provider — see `../theme/colors.ts` and
+ * `../theme/CellDiagramThemeProvider.tsx`. Importing this object continues
+ * to work but is *not* theme-aware; new code should consume `useColors()`
+ * or `({ theme }) => theme.colors.X` inside `styled` template literals.
+ */
+import { CellDiagramColors, lightColors } from '../theme/colors';
 
-    OUTLINE = '#393939',
-    OUTLINE_VARIANT = '#808080',
-
-    ERROR = '#ED2633',
-}
+export const Colors: CellDiagramColors = lightColors;
+export type Colors = CellDiagramColors;
 
 export const LINK_WIDTH = {
     DEFAULT: 2,

--- a/src/stories/ProjectDiagram/DarkMode.stories.tsx
+++ b/src/stories/ProjectDiagram/DarkMode.stories.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import { CellDiagram } from "../../Diagram";
+import { Container } from "../utils";
+import { allComponentModel } from "./data/models";
+
+/**
+ * Demonstrates the new `mode` and `colors` props introduced in v0.3.0.
+ *
+ * - `Light` and `Dark` cover the two presets.
+ * - `BrandOverride` shows a partial token override applied on top of the
+ *   dark preset — useful for host apps that want to snap accents to their
+ *   own primary color.
+ *
+ * Toggle the `mode` control in the toolbar to swap between presets without
+ * remounting; zoom and selection state persist across the swap.
+ */
+const meta: Meta<typeof CellDiagram> = {
+    title: "Theming/Dark Mode",
+    component: CellDiagram,
+    decorators: [
+        (Story, context) => {
+            // Pick a wrapper background that matches the active mode so the
+            // canvas isn't framed by a clashing color.
+            const bg = context.args.mode === "dark" ? "#0f1117" : "#ffffff";
+            return (
+                <div style={{ width: "100vw", height: "100vh", background: bg }}>
+                    <Container>{Story()}</Container>
+                </div>
+            );
+        },
+    ],
+    argTypes: {
+        mode: {
+            control: { type: "inline-radio" },
+            options: ["light", "dark"],
+        },
+    },
+    parameters: {
+        layout: "fullscreen",
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Light: Story = {
+    args: {
+        project: allComponentModel,
+        mode: "light",
+    },
+};
+
+export const Dark: Story = {
+    args: {
+        project: allComponentModel,
+        mode: "dark",
+    },
+};
+
+export const BrandOverride: Story = {
+    args: {
+        project: allComponentModel,
+        mode: "dark",
+        colors: {
+            // Snap the brand accent to a custom hue while keeping the rest
+            // of the dark preset.
+            PRIMARY: "#22D3EE",
+            PRIMARY_HOVER: "#67E8F9",
+        },
+    },
+};

--- a/src/theme/CellDiagramThemeProvider.tsx
+++ b/src/theme/CellDiagramThemeProvider.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import React, { ReactNode, useMemo } from 'react';
+import {
+    ThemeProvider as EmotionThemeProvider,
+    useTheme as useEmotionTheme,
+} from '@emotion/react';
+import { createTheme } from '@mui/material/styles';
+import {
+    CellDiagramColors,
+    CellDiagramThemeMode,
+    presetForMode,
+} from './colors';
+import {
+    CellDiagramThemeContext,
+    CellDiagramThemeContextValue,
+} from './ThemeContext';
+
+export interface CellDiagramThemeProviderProps {
+    /** Preset to start from. Defaults to `'light'`. */
+    mode?: CellDiagramThemeMode;
+    /**
+     * Optional per-token overrides merged on top of the preset. Use this to
+     * snap the diagram to a host brand palette without giving up the preset
+     * defaults for the rest of the tokens.
+     */
+    colors?: Partial<CellDiagramColors>;
+    children: ReactNode;
+}
+
+/**
+ * Default MUI v5 theme used when the diagram is rendered without a host
+ * `ThemeProvider`. We compute it once at module load — its fields
+ * (`palette`, `typography`, `zIndex`, etc.) are what MUI v5 components like
+ * `Tooltip`, `IconButton`, and `CircularProgress` require to render.
+ *
+ * The MUI palette `mode` is set per-render via the provider below so MUI's
+ * own light/dark defaults (e.g. `palette.action.*`) line up with the
+ * diagram's `mode` prop.
+ */
+const muiDefaultLight = createTheme({ palette: { mode: 'light' } });
+const muiDefaultDark = createTheme({ palette: { mode: 'dark' } });
+
+/**
+ * Internal provider used by `<CellDiagram>` to expose the active palette to
+ * every styled component in the tree.
+ *
+ * Routes through:
+ *   1. `CellDiagramThemeContext` — for hook consumers (`useColors`).
+ *   2. Emotion's `ThemeProvider` — for `styled\`...\`` template literals
+ *      that interpolate `({ theme }) => theme.colors.X`.
+ *
+ * **Why we merge with a MUI theme**: MUI v5 components (`Tooltip`,
+ * `IconButton`, `CircularProgress`, …) read their theme from the same
+ * Emotion context this provider sets. If we hand them a bare
+ * `{ colors: ... }` object they crash trying to read `theme.zIndex.tooltip`
+ * / `theme.typography.pxToRem` / `theme.palette.primary`. So we always
+ * merge our `colors` token bag on top of either the parent theme (if a host
+ * `ThemeProvider` is in scope) or MUI's default theme — preserving every
+ * field MUI v5 needs while adding `colors` for our own styled components.
+ */
+export function CellDiagramThemeProvider({
+    mode = 'light',
+    colors,
+    children,
+}: CellDiagramThemeProviderProps) {
+    const parentTheme = useEmotionTheme() as Record<string, unknown>;
+
+    const value = useMemo<CellDiagramThemeContextValue>(() => {
+        const preset = presetForMode(mode);
+        const merged: CellDiagramColors = colors
+            ? { ...preset, ...colors }
+            : preset;
+        return { mode, colors: merged };
+    }, [mode, colors]);
+
+    const emotionTheme = useMemo(() => {
+        // Treat the parent theme as a base only if it looks like a MUI
+        // theme (has `palette`). Otherwise fall back to a fresh MUI default
+        // matching our active mode so MUI v5 components have what they
+        // need.
+        const hasMuiShape =
+            parentTheme &&
+            typeof parentTheme === 'object' &&
+            'palette' in parentTheme &&
+            'typography' in parentTheme;
+        const base = hasMuiShape
+            ? parentTheme
+            : mode === 'dark'
+            ? muiDefaultDark
+            : muiDefaultLight;
+        return { ...base, colors: value.colors };
+    }, [parentTheme, mode, value.colors]);
+
+    return (
+        <CellDiagramThemeContext.Provider value={value}>
+            <EmotionThemeProvider theme={emotionTheme}>
+                {children}
+            </EmotionThemeProvider>
+        </CellDiagramThemeContext.Provider>
+    );
+}

--- a/src/theme/ThemeContext.tsx
+++ b/src/theme/ThemeContext.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { createContext, useContext } from 'react';
+import {
+    CellDiagramColors,
+    CellDiagramThemeMode,
+    lightColors,
+} from './colors';
+
+export interface CellDiagramThemeContextValue {
+    mode: CellDiagramThemeMode;
+    colors: CellDiagramColors;
+}
+
+/**
+ * Context default — light mode with the historical palette. Components
+ * rendered outside `<CellDiagramThemeProvider>` therefore behave exactly as
+ * they did before dark-mode support landed.
+ */
+const defaultValue: CellDiagramThemeContextValue = {
+    mode: 'light',
+    colors: lightColors,
+};
+
+export const CellDiagramThemeContext =
+    createContext<CellDiagramThemeContextValue>(defaultValue);
+
+/** Returns the active color palette. */
+export function useColors(): CellDiagramColors {
+    return useContext(CellDiagramThemeContext).colors;
+}
+
+/** Returns the active mode (`'light' | 'dark'`). */
+export function useThemeMode(): CellDiagramThemeMode {
+    return useContext(CellDiagramThemeContext).mode;
+}

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * The full color vocabulary the cell diagram paints with.
+ *
+ * The shape mirrors a Material You-style token system. `lightColors` is the
+ * historical default and matches the original `Colors` enum byte-for-byte;
+ * `darkColors` is the dark-mode counterpart. Host applications can also
+ * override individual tokens by passing a `colors` prop to `<CellDiagram>`.
+ */
+export type CellDiagramColors = {
+    PRIMARY: string;
+    ON_PRIMARY: string;
+    PRIMARY_CONTAINER: string;
+    /** Hover accent for primary-tinted clickable surfaces (e.g. project node title). */
+    PRIMARY_HOVER: string;
+
+    SECONDARY: string;
+    ON_SECONDARY: string;
+    SECONDARY_CONTAINER: string;
+
+    SURFACE_BRIGHT: string;
+    SURFACE: string;
+    SURFACE_DIM: string;
+    SURFACE_CONTAINER: string;
+    ON_SURFACE: string;
+    ON_SURFACE_VARIANT: string;
+
+    OUTLINE: string;
+    OUTLINE_VARIANT: string;
+
+    ERROR: string;
+};
+
+/** Default light palette — byte-identical to the original `Colors` enum. */
+export const lightColors: Readonly<CellDiagramColors> = Object.freeze({
+    PRIMARY: '#5567D5',
+    ON_PRIMARY: '#FFF',
+    PRIMARY_CONTAINER: '#F0F1FB',
+    PRIMARY_HOVER: '#2c09ed',
+
+    SECONDARY: '#ffaf4d',
+    ON_SECONDARY: '#FFF',
+    SECONDARY_CONTAINER: '#fffaf2',
+
+    SURFACE_BRIGHT: '#FFF',
+    SURFACE: '#F7F8FB',
+    SURFACE_DIM: '#CBCEDB',
+    SURFACE_CONTAINER: '#cfd1f3',
+    ON_SURFACE: '#000',
+    ON_SURFACE_VARIANT: '#40404B',
+
+    OUTLINE: '#393939',
+    OUTLINE_VARIANT: '#808080',
+
+    ERROR: '#ED2633',
+});
+
+/**
+ * Dark palette. Brand accents (PRIMARY, SECONDARY, ERROR) are kept identical
+ * to the light palette so link strokes and status indicators remain
+ * recognizable; surfaces, outlines, and on-surface text invert.
+ */
+export const darkColors: Readonly<CellDiagramColors> = Object.freeze({
+    PRIMARY: '#5567D5',
+    ON_PRIMARY: '#FFF',
+    PRIMARY_CONTAINER: '#2A2F55',
+    PRIMARY_HOVER: '#8FA0EA',
+
+    SECONDARY: '#ffaf4d',
+    ON_SECONDARY: '#FFF',
+    SECONDARY_CONTAINER: '#3A2A10',
+
+    SURFACE_BRIGHT: '#25252B',
+    SURFACE: '#1B1B1F',
+    SURFACE_DIM: '#141418',
+    SURFACE_CONTAINER: '#2E2F3A',
+    ON_SURFACE: '#E6E6EC',
+    ON_SURFACE_VARIANT: '#B5B5C0',
+
+    OUTLINE: '#C7C7D1',
+    OUTLINE_VARIANT: '#5A5A66',
+
+    ERROR: '#ED2633',
+});
+
+export type CellDiagramThemeMode = 'light' | 'dark';
+
+/** Resolves the preset palette for a mode. */
+export function presetForMode(mode: CellDiagramThemeMode): Readonly<CellDiagramColors> {
+    return mode === 'dark' ? darkColors : lightColors;
+}

--- a/src/theme/emotion.d.ts
+++ b/src/theme/emotion.d.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { CellDiagramColors } from './colors';
+
+/**
+ * Module augmentation so `styled\`color: ${({ theme }) => theme.colors.X}\``
+ * is strongly typed inside the cell-diagram package.
+ *
+ * Note: this augments the `Theme` interface globally for the package, but
+ * because we wrap the diagram in our own Emotion `<ThemeProvider>` the
+ * augmentation is only meaningful inside cell-diagram's own styled
+ * components. Consumer apps with their own Emotion theme are unaffected at
+ * runtime — they still get whatever theme they passed; this just satisfies
+ * TypeScript at build time.
+ */
+declare module '@emotion/react' {
+    export interface Theme {
+        colors: CellDiagramColors;
+    }
+}

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+export { lightColors, darkColors, presetForMode } from './colors';
+export type { CellDiagramColors, CellDiagramThemeMode } from './colors';
+export {
+    CellDiagramThemeContext,
+    useColors,
+    useThemeMode,
+} from './ThemeContext';
+export type { CellDiagramThemeContextValue } from './ThemeContext';
+export { CellDiagramThemeProvider } from './CellDiagramThemeProvider';
+export type { CellDiagramThemeProviderProps } from './CellDiagramThemeProvider';

--- a/src/utils/CanvasStyles.ts
+++ b/src/utils/CanvasStyles.ts
@@ -19,8 +19,13 @@
 import { createStyles, makeStyles } from "@material-ui/core/styles";
 import styled from "@emotion/styled";
 
-import { Colors, MAIN_CELL } from "../resources";
+import { MAIN_CELL } from "../resources";
 
+/**
+ * Structural styles for the SVG canvas wrapper. Kept on MUI v4 `makeStyles`
+ * because it carries no theme-dependent values; the call-sites use the
+ * `canvas` class to size the canvas.
+ */
 export const useStyles = makeStyles(() =>
     createStyles({
         canvas: {
@@ -38,16 +43,16 @@ export const Container = styled.div`
     flex-direction: column;
     justify-content: center;
     font-family: "GilmerRegular";
-    
+
     &.preview-mode {
         padding: 10px;
-        background-image: radial-gradient(${Colors.SURFACE_CONTAINER} 10%, transparent 0px);
+        background-image: radial-gradient(${({ theme }) => theme.colors.SURFACE_CONTAINER} 10%, transparent 0px);
         background-size: 8px 8px;
-        background-color: ${Colors.SURFACE_BRIGHT};
+        background-color: ${({ theme }) => theme.colors.SURFACE_BRIGHT};
         overflow: hidden;
         border-radius: 8px;
         cursor: pointer ;
-        border: 1px solid ${Colors.SURFACE_CONTAINER};
+        border: 1px solid ${({ theme }) => theme.colors.SURFACE_CONTAINER};
     }
 `;
 
@@ -58,16 +63,16 @@ export const DiagramContainer = styled.div`
     justify-content: center;
     height: 100%;
     width: 100%;
-    background-image: radial-gradient(${Colors.SURFACE_CONTAINER} 10%, transparent 0px);
+    background-image: radial-gradient(${({ theme }) => theme.colors.SURFACE_CONTAINER} 10%, transparent 0px);
     background-size: 16px 16px;
-    background-color: ${Colors.SURFACE_BRIGHT};
+    background-color: ${({ theme }) => theme.colors.SURFACE_BRIGHT};
     svg:not(:root) {
         overflow: visible;
     }
     [data-nodeid="${MAIN_CELL}"] {
         pointer-events: none;
     }
-    
+
     &.preview-mode {
         background-size: 8px 8px;
         padding: 5px;


### PR DESCRIPTION
  Introduce an externally-driven theming API on the CellDiagram component so
  host applications can render it in light or dark, or override individual
  tokens for brand fit. Defaults are preserved byte-for-byte — existing
  callers that don't pass `mode` see the same light appearance as before.

  Public API (additive, non-breaking)
  -----------------------------------

    <CellDiagram
      project={project}
      mode?:   'light' | 'dark'            // default: 'light'
      colors?: Partial<CellDiagramColors>  // merged on top of the preset
    />

  New exports: `CellDiagramColors`, `CellDiagramThemeMode`, `lightColors`,
  `darkColors`. Advanced consumers can type-import or build bespoke palettes.

https://github.com/user-attachments/assets/c732cc8f-1b1b-4064-89fb-dac39315e119

  Storybook
  ---------

  New `src/stories/ProjectDiagram/DarkMode.stories.tsx` with `Light`,
  `Dark`, and `BrandOverride` stories plus a `mode` toolbar control. The
  story decorator matches its wrapper bg to the active mode.

  Docs
  ----

  `README.md` grew a full theming section with a Backstage usage example
  covering `mode` and per-token `colors` overrides.

  Migration
  ---------

  - `Colors` is now a frozen object alias of `lightColors`, not a TS `enum`. Value imports (`Colors.PRIMARY`) keep working unchanged; type annotations (`: Colors`) keep working via the exported type alias.
  - Consumers that don't pass `mode` see zero visual change.

  Verified: `npx tsc --noEmit` clean; `pnpm build` clean; both existing and
  new Storybook stories render with zero console errors.

  Refs: https://github.com/openchoreo/openchoreo/issues/3189
