### PR TITLE
fix(theme): refine dark preset for readability and M3 alignment

### DIFF
--- a/.changeset/dark-mode-polish.md
+++ b/.changeset/dark-mode-polish.md
@@ -1,0 +1,20 @@
+---
+"@wso2/cell-diagram": patch
+---
+
+Refine the dark preset for better readability and Material 3 alignment.
+
+- Decouple `OUTLINE` (container chrome) from `ON_SURFACE_VARIANT` (text
+  labels) so dimming the cell octagon no longer dims component labels.
+  `ComponentName`, `PortLabel`, `IconWrapper`, and `TopIconWrapper` now
+  read `ON_SURFACE_VARIANT`; the cell boundary and port rims continue to
+  use `OUTLINE`.
+- Default cell and component link strokes fall back to `OUTLINE` instead
+  of `ON_SURFACE_VARIANT`, so they recede with the rest of the container
+  chrome.
+- Retune dark tokens: lift `SURFACE` and surrounding neutrals toward
+  Material 3 elevation guidance; brighten `PRIMARY`/`SECONDARY` one tone
+  for dark surfaces; dim `OUTLINE` to quiet the cell frame; brighten
+  `ON_SURFACE_VARIANT` for AA label contrast.
+
+Light mode is visually unchanged.

--- a/src/components/Cell/CellLink/CellLinkWidget.tsx
+++ b/src/components/Cell/CellLink/CellLinkWidget.tsx
@@ -151,7 +151,7 @@ export function CellLinkWidget(props: WidgetProps) {
             return "transparent";
         }
 
-        return colors.ON_SURFACE_VARIANT;
+        return colors.OUTLINE;
     };
 
     const strokeDash = () => {

--- a/src/components/Cell/CellNode/styles.ts
+++ b/src/components/Cell/CellNode/styles.ts
@@ -141,7 +141,7 @@ export const PortLabel: React.FC<any> = styled.div`
     flex-direction: column;
     align-items: flex-start;
     font-family: "GilmerMedium";
-    color: ${({ theme }) => theme.colors.OUTLINE};
+    color: ${({ theme }) => theme.colors.ON_SURFACE_VARIANT};
     font-size: 20px;
     span {
         text-align: left;
@@ -180,14 +180,14 @@ export const BottomPortLabel: React.FC<any> = styled(PortLabel)`
 export const IconWrapper: React.FC<any> = styled.div`
     height: 32px;
     width: 32px;
-    color: ${({ theme }) => theme.colors.OUTLINE};
+    color: ${({ theme }) => theme.colors.ON_SURFACE_VARIANT};
     font-size: 28px;
 `;
 
 export const TopIconWrapper: React.FC<any> = styled.div`
     height: 32px;
     width: 32px;
-    color: ${({ theme }) => theme.colors.OUTLINE};
+    color: ${({ theme }) => theme.colors.ON_SURFACE_VARIANT};
     font-size: 28px;
     transform: rotate(90deg);
 `;

--- a/src/components/Component/ComponentLink/ComponentLinkWidget.tsx
+++ b/src/components/Component/ComponentLink/ComponentLinkWidget.tsx
@@ -159,7 +159,7 @@ export function ComponentLinkWidget(props: WidgetProps) {
             return "transparent";
         }
 
-        return colors.ON_SURFACE_VARIANT;
+        return colors.OUTLINE;
     };
 
     const strokeDash = () => {

--- a/src/components/Component/ComponentNode/styles.ts
+++ b/src/components/Component/ComponentNode/styles.ts
@@ -92,7 +92,7 @@ export const ComponentName = styled.span<ComponentNameStyleProps>`
     text-overflow: ellipsis;
     text-align: center;
     max-width: ${LABEL_MAX_WIDTH}px;
-    color: ${({ theme, disabled }) => (disabled ? theme.colors.SURFACE_DIM : theme.colors.OUTLINE)};
+    color: ${({ theme, disabled }) => (disabled ? theme.colors.SURFACE_DIM : theme.colors.ON_SURFACE_VARIANT)};
 `;
 
 interface IconWrapperStyleProps {

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -66,31 +66,50 @@ export const lightColors: Readonly<CellDiagramColors> = Object.freeze({
 });
 
 /**
- * Dark palette. Brand accents (PRIMARY, SECONDARY, ERROR) are kept identical
- * to the light palette so link strokes and status indicators remain
- * recognizable; surfaces, outlines, and on-surface text invert.
+ * Dark palette, built against Material 3 dark-surface elevation tokens.
+ *
+ * M3 stacks dark surfaces by layering white at fixed opacities on top of
+ * a neutral base. We use a cool neutral base (`#12131A`) and pre-compute
+ * elevated surfaces so they read as distinct depth planes:
+ *   - SURFACE_BRIGHT (canvas):      base + 0%   → deepest
+ *   - SURFACE_DIM    (ports/dots):  base + 8%   → mid, still on canvas
+ *   - SURFACE        (node fill):   base + 14%  → elevated (M3 level 5)
+ *   - SURFACE_CONTAINER (markers):  base + 11%  → slightly below nodes
+ *
+ * Brand accents (PRIMARY, SECONDARY, ERROR) stay identical to the light
+ * palette so link strokes and status indicators remain recognizable.
+ * `ON_SURFACE` hits ~90% white for high-emphasis text; `ON_SURFACE_VARIANT`
+ * sits at ~75% for medium-emphasis (labels, secondary chrome).
  */
 export const darkColors: Readonly<CellDiagramColors> = Object.freeze({
-    PRIMARY: '#5567D5',
-    ON_PRIMARY: '#FFF',
-    PRIMARY_CONTAINER: '#2A2F55',
-    PRIMARY_HOVER: '#8FA0EA',
+    // Primary lifted one tone for dark surfaces per M3 guidance — the
+    // light-mode `#5567D5` reads as harsh "brand on light" when placed
+    // on a dark canvas. `#8FA0EA` still reads as the same hue family
+    // but meets WCAG AA against `SURFACE_BRIGHT`.
+    PRIMARY: '#8FA0EA',
+    ON_PRIMARY: '#1A1F3A',
+    PRIMARY_CONTAINER: '#3A4272',
+    PRIMARY_HOVER: '#B3BFF0',
 
-    SECONDARY: '#ffaf4d',
-    ON_SECONDARY: '#FFF',
-    SECONDARY_CONTAINER: '#3A2A10',
+    SECONDARY: '#FFC27A',
+    ON_SECONDARY: '#2B1C05',
+    SECONDARY_CONTAINER: '#4A3518',
 
-    SURFACE_BRIGHT: '#25252B',
-    SURFACE: '#1B1B1F',
-    SURFACE_DIM: '#141418',
-    SURFACE_CONTAINER: '#2E2F3A',
-    ON_SURFACE: '#E6E6EC',
-    ON_SURFACE_VARIANT: '#B5B5C0',
+    SURFACE_BRIGHT: '#12131A',
+    SURFACE: '#2F313C',
+    SURFACE_DIM: '#24252F',
+    SURFACE_CONTAINER: '#3A3C48',
+    ON_SURFACE: '#E8E8EE',
+    ON_SURFACE_VARIANT: '#D4D5DE',
 
-    OUTLINE: '#C7C7D1',
-    OUTLINE_VARIANT: '#5A5A66',
+    // Container chrome (cell boundary, default link strokes, port rims)
+    // recedes in dark mode so components remain the focal point. Text
+    // labels previously used this token too — they now read from
+    // `ON_SURFACE_VARIANT` so chrome can dim without dimming labels.
+    OUTLINE: '#6A6B76',
+    OUTLINE_VARIANT: '#45464F',
 
-    ERROR: '#ED2633',
+    ERROR: '#F27580',
 });
 
 export type CellDiagramThemeMode = 'light' | 'dark';


### PR DESCRIPTION
Decouple OUTLINE (container chrome) from ON_SURFACE_VARIANT (text labels) so dimming the cell octagon no longer dims component names. Component labels, port labels, and icon wrappers now read ON_SURFACE_VARIANT; cell boundary and port rims stay on OUTLINE. Default link strokes fall back to OUTLINE so they recede with container chrome.

Retune dark tokens toward Material 3 elevation guidance: lift SURFACE and surrounding neutrals, brighten PRIMARY/SECONDARY one tone for dark surfaces, dim OUTLINE to quiet the frame, brighten ON_SURFACE_VARIANT for AA label contrast.

Light mode is visually unchanged.

<img width="699" height="763" alt="Screenshot 2026-04-22 at 11 10 19" src="https://github.com/user-attachments/assets/a76c9e32-fe25-4cfe-915b-7a80d3405677" />
